### PR TITLE
Elab app log table integration and Lab Book View

### DIFF
--- a/src/proespm/ec/PalmSens/ca.py
+++ b/src/proespm/ec/PalmSens/ca.py
@@ -24,8 +24,10 @@ class CaPalmSens(Measurement):
     (testfile: PS241105-2.csv)
     """
 
+    measurement_family = "Electro chemistry (PalmSens)"
+
     controller = "PalmSens"
-    ec_type = "Chronoamperometry"
+    op_mode = "Chronoamperometry"
 
     def __init__(self, filepath: Path) -> None:
         self.fileinfo: Fileinfo = Fileinfo(filepath)

--- a/src/proespm/ec/PalmSens/cp.py
+++ b/src/proespm/ec/PalmSens/cp.py
@@ -24,8 +24,10 @@ class CpPalmSens(Measurement):
     (testfile: PS241105-1.csv)
     """
 
+    measurement_family = "Electro chemistry (PalmSens)"
+
     controller = "PalmSens"
-    ec_type = "Chronopotentiometry"
+    op_mode = "Chronopotentiometry"
 
     def __init__(self, filepath: Path) -> None:
         self.fileinfo: Fileinfo = Fileinfo(filepath)

--- a/src/proespm/ec/PalmSens/cv.py
+++ b/src/proespm/ec/PalmSens/cv.py
@@ -24,8 +24,10 @@ class CvPalmSens(Measurement):
     (testfile: PS241105-3.csv)
     """
 
+    measurement_family = "Electro chemistry (PalmSens)"
+
     controller = "PalmSens"
-    ec_type = "Cyclic Voltammetry"
+    op_mode = "Cyclic Voltammetry"
 
     def __init__(self, filepath: Path) -> None:
         self.fileinfo: Fileinfo = Fileinfo(filepath)

--- a/src/proespm/ec/PalmSens/eis.py
+++ b/src/proespm/ec/PalmSens/eis.py
@@ -26,8 +26,10 @@ class EisPalmSens(Measurement):
     (testfile: PS241105-14.csv)
     """
 
+    measurement_family = "Electro chemistry (PalmSens)"
+
     controller = "PalmSens"
-    ec_type = "Impedence Spectroscopy"
+    op_mode = "Impedence Spectroscopy"
 
     def __init__(self, filepath: Path) -> None:
         self.fileinfo: Fileinfo = Fileinfo(filepath)

--- a/src/proespm/ec/PalmSens/lsv.py
+++ b/src/proespm/ec/PalmSens/lsv.py
@@ -24,8 +24,10 @@ class LsvPalmSens(Measurement):
     (testfile: PS241105-13.csv)
     """
 
+    measurement_family = "Electro chemistry (PalmSens)"
+
     controller = "PalmSens"
-    ec_type = "Linear Sweep Voltammetry"
+    op_mode = "Linear Sweep Voltammetry"
 
     def __init__(self, filepath: Path) -> None:
         self.fileinfo: Fileinfo = Fileinfo(filepath)

--- a/src/proespm/ec/PalmSens/pssession.py
+++ b/src/proespm/ec/PalmSens/pssession.py
@@ -26,6 +26,8 @@ class PalmSensType(Enum):
 class PalmSensSession(Measurement):
     controller = "PalmSens"
 
+    measurement_family = "Electro chemistry (PalmSens)"
+
     def __init__(self, filepath: Path) -> None:
         self.fileinfo: Fileinfo = Fileinfo(filepath)
         self.script: str | None = None
@@ -37,7 +39,7 @@ class PalmSensSession(Measurement):
 
         title = cast(str, self.parsed["Measurements"][0]["Title"])
         self.session_type: PalmSensType = PalmSensType(title)
-        self.ec_type = self.session_type.value
+        self.op_mode = self.session_type.value
 
         timestamp_in_10e7: int = cast(
             int, self.parsed["Measurements"][0]["TimeStamp"]

--- a/src/proespm/ec/ec_labview.py
+++ b/src/proespm/ec/ec_labview.py
@@ -18,8 +18,10 @@ from proespm.measurement import Measurement
 class CvLabview(Measurement):
     """Class handeling the CV files from self-written LabView software"""
 
+    measurement_family = "Electro chemistry"
+
     controller = "LabView"
-    ec_type = "Cyclic Voltammetry"
+    op_mode = "Cyclic Voltammetry"
 
     x_axis_label = "E_WE [V]"
     y_axis_label = "I_WE [A]"
@@ -181,8 +183,10 @@ class CvLabview(Measurement):
 class CaLabview(Measurement):
     """Class handling the CA files from self-written LabView software"""
 
+    measurement_family = "Electro chemistry"
+
     controller = "LabView"
-    ec_type = "Chronoamperometry"
+    op_mode = "Chronoamperometry"
 
     x_axis_label = "t [s]"
     y_axis_label = "I_WE [A]"
@@ -313,8 +317,10 @@ class CaLabview(Measurement):
 class FftLabview(Measurement):
     """Class handeling the FFT files from self-written LabView software"""
 
+    measurement_family = "Electro chemistry"
+
     controller = "LabView"
-    ec_type = "FFT"
+    op_mode = "FFT"
 
     x_axis_label = "Frequency [Hz]"
     y_axis_label = "PSD(I_t) [dB]"

--- a/src/proespm/ec/nordic_ec4.py
+++ b/src/proespm/ec/nordic_ec4.py
@@ -29,6 +29,8 @@ RATE_REGEX = re.compile(r"Rate(\s+[\d.-]+)")
 class NordicEc4(Measurement):
     """Class for handling Nordic Electrochemistry EC4 files (.txt)"""
 
+    measurement_family = "Electro chemistry"
+
     controller = "Nordic EC4"
 
     def __init__(self, filepath: Path) -> None:
@@ -41,7 +43,7 @@ class NordicEc4(Measurement):
         self.scanrate: float | None = None
         self.read_params()
 
-        self.ec_type: str | None = None
+        self.op_mode: str | None = None
 
         self.data: list[NDArray[np.float64]] = [self.read_cv_data(filepath)]
         self.script: str | None = None
@@ -75,7 +77,7 @@ class NordicEc4(Measurement):
 
     def plot(self):
         # Unfortunately, we cannot tell the type by the file ifself, external info needed
-        if self.ec_type == "ca_ec4":
+        if self.op_mode == "ca_ec4":
             self.plot_ca()
             return
 

--- a/src/proespm/fastspm/atom_tracking.py
+++ b/src/proespm/fastspm/atom_tracking.py
@@ -21,6 +21,8 @@ class AtomTracking(Measurement):
         filepath (str): Full path to the .h5 file
     """
 
+    measurement_family = "FastSPM"
+
     op_mode = "AT"
 
     def __init__(self, filepath: Path) -> None:

--- a/src/proespm/fastspm/error_topography.py
+++ b/src/proespm/fastspm/error_topography.py
@@ -21,6 +21,8 @@ class ErrorTopography(Measurement):
         filepath (str): Full path to the .h5 file
     """
 
+    measurement_family = "FastSPM"
+
     op_mode = "ET"
 
     def __init__(self, filepath: Path) -> None:

--- a/src/proespm/fastspm/fast_scan.py
+++ b/src/proespm/fastspm/fast_scan.py
@@ -21,6 +21,8 @@ class FastScan(Measurement):
         filepath (str): Full path to the .h5 file
     """
 
+    measurement_family = "FastSPM"
+
     op_mode = "FS"
 
     def __init__(self, filepath: Path) -> None:

--- a/src/proespm/fastspm/high_speed.py
+++ b/src/proespm/fastspm/high_speed.py
@@ -21,6 +21,8 @@ class HighSpeed(Measurement):
         filepath (str): Full path to the .h5 file
     """
 
+    measurement_family = "FastSPM"
+
     op_mode = "HS"
 
     def __init__(self, filepath: Path) -> None:

--- a/src/proespm/fastspm/resonance_frequency.py
+++ b/src/proespm/fastspm/resonance_frequency.py
@@ -18,6 +18,8 @@ class ResonanceFrequency(Measurement):
         filepath (str): Full path to the .h5 file
     """
 
+    measurement_family = "FastSPM"
+
     op_mode = "RF"
 
     def __init__(self, filepath: Path) -> None:

--- a/src/proespm/fastspm/slow_image.py
+++ b/src/proespm/fastspm/slow_image.py
@@ -21,6 +21,8 @@ class SlowImage(Measurement):
         filepath (str): Full path to the .h5 file
     """
 
+    measurement_family = "FastSPM"
+
     op_mode = "SI"
 
     def __init__(self, filepath: Path) -> None:

--- a/src/proespm/misc/elab_ftw.py
+++ b/src/proespm/misc/elab_ftw.py
@@ -1,28 +1,34 @@
 from __future__ import annotations
-from pathlib import Path
-from typing import Any, Hashable, Self, final, override
-from proespm.config import Config
-from proespm.measurement import Measurement
-import json
-from datetime import datetime
 
 import html
+import json
+import re
+import warnings
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Self, final, override
+
 from bs4 import BeautifulSoup
+
+from proespm.config import Config
+from proespm.measurement import Measurement
+
+_COLOR_PALETTE = [
+    "#5B8DB8", "#E8A838", "#7CBB7A", "#C47AC0", "#6BBFBE",
+    "#E07B5A", "#9B8DC8", "#B5C45A", "#D4857A", "#5AA0A0",
+]
 
 
 def extract_elabftw(filepath: Path) -> list[ElabFtw]:
-    with open(filepath, "r") as f:
+    with open(filepath) as f:
         json_content = json.load(f)
 
-    entries = _parse_html_body(json_content["body_html"])
+    entries = _parse_html_body(
+        json_content.get("body") or json_content.get("body_html", "")
+    )
     return [
-        ElabFtw(
-            timestamp=k,
-            text=v,
-            number=i + 1,
-            json_content=json_content,
-        )
-        for i, (k, v) in enumerate(entries.items())
+        ElabFtw(row=entry, number=i + 1, json_content=json_content)
+        for i, entry in enumerate(entries)
     ]
 
 
@@ -32,24 +38,32 @@ class ElabFtw(Measurement):
 
     def __init__(
         self,
-        timestamp: datetime,
-        text: str,
+        row: dict[str, Any],
         number: int,
-        json_content: dict[Hashable, Any],
+        json_content: dict[str, Any],
     ) -> None:
-        self._datetime = timestamp
-        self.text = text
+        self._datetime: datetime = row["timestamp"]
+        self.text: str = row["content_html"]
         self._number = number
+        self.initials: str = row["initials"]
+        self.app_version: str = row["app_version"]
 
-        self.title: str = json_content["title"]
-        self.type_: str = json_content["type"]
-        self.operator: str = json_content["fullname"]
-        self.team: str = json_content["team_name"]
-        self.tags: str = json_content["tags"]
+        self.elab_id: int = json_content["id"]
+        is_experiment = json_content.get("type") == "experiments"
+        self.is_experiment: bool = is_experiment
+
+        self.title: str = json_content.get("title", "")
+        self.type_: str = "experiment" if is_experiment else "resource"
+        self.operator: str = json_content.get("fullname") or ""
+        self.team: str = json_content.get("team_name") or ""
+        self.tags: str = json_content.get("tags") or ""
+
+        self.border_color: str = _COLOR_PALETTE[self.elab_id % len(_COLOR_PALETTE)]
+        self.border_style: str = "solid" if is_experiment else "dashed"
 
     @override
     def m_id(self) -> str:
-        return f"{self.title} - {self._number}"
+        return f"{self.title} (#{self.elab_id}) - {self._number}"
 
     @override
     def get_datetime(self) -> datetime:
@@ -64,41 +78,56 @@ class ElabFtw(Measurement):
         return "elab_ftw.j2"
 
 
-def _parse_html_body(raw_string: str) -> dict[datetime, str]:
-    """Parsing of timestamps and corresponding text from escaped HTML tables.
-
-    Returns
-    A ist of dicts: {timestamp: datetime | str, text: str}
-    """
-
-    # 1. Unescape \u003C etc. into real HTML
+def _parse_html_body(raw_string: str) -> list[dict[str, Any]]:
     html_string = html.unescape(raw_string)
-
-    # 2. Parse HTML
     soup = BeautifulSoup(html_string, "html.parser")
 
-    entries: dict[datetime, str] = dict()
+    entries: list[dict[str, Any]] = []
 
-    # 3. Iterate over table rows
-    for tr_tag in soup.find_all("tr"):
-        td_tag = tr_tag.find_all("td")
-        if len(td_tag) != 2:
+    for table in soup.find_all("table"):
+        # Identify elab-app log tables by their signature identifier row
+        rows = table.find_all("tr")
+        is_elab_table = any(
+            (cells := tr.find_all("td"))
+            and cells[0].get_text(strip=True) == "elab_app"
+            for tr in rows
+        )
+        if not is_elab_table:
             continue
 
-        time_cell, text_cell = td_tag
+        for tr in rows:
+            # Skip header rows
+            if tr.find("th"):
+                continue
 
-        timestamps = [
-            t.strip() for t in time_cell.stripped_strings if t.strip()
-        ]
+            cells = tr.find_all("td")
+            if not cells:
+                continue
 
-        texts = [text_cell.decode_contents().strip()]
+            # Skip identifier row
+            if cells[0].get_text(strip=True) == "elab_app":
+                continue
 
-        if len(timestamps) == len(texts):
-            for ts, txt in zip(timestamps, texts):
-                entries.update({datetime.fromisoformat(ts): txt})
-        else:
-            combined_text = " ".join(texts)
-            for ts in timestamps:
-                entries.update({datetime.fromisoformat(ts): combined_text})
+            # Skip system back-reference rows
+            if len(cells) >= 3 and cells[2].get_text(strip=True) == "#":
+                continue
+
+            app_version = cells[3].get_text(strip=True) if len(cells) >= 4 else "2.x"
+
+            entries.append({
+                "timestamp": datetime.fromisoformat(cells[0].get_text(strip=True)),
+                "content_html": cells[1].decode_contents().strip(),
+                "initials": cells[2].get_text(strip=True),
+                "app_version": app_version,
+            })
+
+    # Warn for unexpected future versions (not v2.x legacy sentinel, not v2.* or v3.*)
+    for entry in entries:
+        ver = entry["app_version"]
+        if ver != "2.x" and not re.match(r"^v[23]\.", ver):
+            warnings.warn(
+                f"elab-app row version '{ver}' is not understood by this parser; "
+                "row may not display correctly"
+            )
 
     return entries

--- a/src/proespm/misc/elab_ftw.py
+++ b/src/proespm/misc/elab_ftw.py
@@ -28,6 +28,8 @@ def extract_elabftw(filepath: Path) -> list[ElabFtw]:
 
 @final
 class ElabFtw(Measurement):
+    measurement_family = "ElabFTW"
+
     def __init__(
         self,
         timestamp: datetime,

--- a/src/proespm/misc/image.py
+++ b/src/proespm/misc/image.py
@@ -13,6 +13,8 @@ from proespm.measurement import Measurement
 class Image(Measurement):
     """Class handeling image files (.png, .jpg, .jpeg)"""
 
+    measurement_family = "Image"
+
     def __init__(self, filepath: Path) -> None:
         self.fileinfo = Fileinfo(filepath)
 

--- a/src/proespm/misc/qcmb.py
+++ b/src/proespm/misc/qcmb.py
@@ -15,6 +15,8 @@ from proespm.measurement import Measurement
 
 @final
 class Qcmb(Measurement):
+    measurement_family = "Qcmb"
+
     def __init__(self, filepath: Path) -> None:
         self.fileinfo = Fileinfo(filepath)
 

--- a/src/proespm/misc/rga.py
+++ b/src/proespm/misc/rga.py
@@ -17,6 +17,8 @@ from proespm.measurement import Measurement
 
 @final
 class RgaMassScan(Measurement):
+    measurement_family = "RGA MassScan"
+
     op_mode = "MASSSCAN"
 
     def __init__(self, filepath: Path) -> None:
@@ -106,6 +108,8 @@ class RgaChannel:
 @final
 class RgaTimeSeries(Measurement):
     op_mode = "TIMESERIES"
+
+    measurement_family = "RGA Timeseries"
 
     def __init__(self, filepath: Path) -> None:
         self.fileinfo = Fileinfo(filepath)

--- a/src/proespm/misc/tpd.py
+++ b/src/proespm/misc/tpd.py
@@ -18,6 +18,8 @@ from proespm.measurement import Measurement
 
 @final
 class Tpd(Measurement):
+    measurement_family = "TPD"
+
     def __init__(self, filepath: Path) -> None:
         self.fileinfo = Fileinfo(filepath)
 

--- a/src/proespm/processing.py
+++ b/src/proespm/processing.py
@@ -21,7 +21,7 @@ from proespm.fastspm.high_speed import HighSpeed
 from proespm.fastspm.resonance_frequency import ResonanceFrequency
 from proespm.fastspm.slow_image import SlowImage
 from proespm.measurement import Measurement
-from proespm.misc.elab_ftw import extract_elabftw
+from proespm.misc.elab_ftw import extract_elabftw, ElabFtw
 from proespm.misc.image import Image
 from proespm.misc.qcmb import Qcmb
 from proespm.misc.rga import RgaMassScan, RgaTimeSeries
@@ -303,6 +303,8 @@ def create_html(
         template_dir = os.path.join(os.path.dirname(__file__), "templates")
 
     env = Environment(loader=FileSystemLoader(template_dir))
+    env.globals["isinstance"] = isinstance
+    env.globals["ElabFTW"] = ElabFtw
 
     template = env.get_template("base_template.j2")
 

--- a/src/proespm/spectroscopy/aes_staib.py
+++ b/src/proespm/spectroscopy/aes_staib.py
@@ -22,6 +22,8 @@ class AesStaib(Measurement):
         filepath (str): Path to .dat or .vms file
     """
 
+    measurement_family = "Spectroscopy"
+
     def __init__(self, filepath: Path) -> None:
         self.fileinfo = Fileinfo(filepath)
 

--- a/src/proespm/spectroscopy/xps_eis.py
+++ b/src/proespm/spectroscopy/xps_eis.py
@@ -19,6 +19,8 @@ from proespm.measurement import Measurement
 class XpsEis(Measurement):
     """Class handling Omicron EIS XPS files (.txt)"""
 
+    measurement_family = "Spectroscopy"
+
     def __init__(self, filepath: Path) -> None:
         self.fileinfo = Fileinfo(filepath)
         self.data = self.read_xps_eis_txt(filepath)

--- a/src/proespm/spm/flm.py
+++ b/src/proespm/spm/flm.py
@@ -22,6 +22,8 @@ class StmFlm(StmMul):
 
     """
 
+    measurement_family = "SPM"
+
     def __init__(self, filepath: Path) -> None:
         super().__init__(filepath)
 

--- a/src/proespm/spm/mtrx.py
+++ b/src/proespm/spm/mtrx.py
@@ -26,6 +26,8 @@ class StmMatrix(Measurement):
         filepath (str): Full path to the .Z_mtrx file
     """
 
+    measurement_family = "SPM"
+
     def __init__(self, filepath: Path) -> None:
         self.fileinfo = Fileinfo(filepath)
         self.slide_num: int | None = None

--- a/src/proespm/spm/mul.py
+++ b/src/proespm/spm/mul.py
@@ -19,6 +19,8 @@ class StmMul(Measurement):
         filepath (str): Full path to the .mul file
     """
 
+    measurement_family = "SPM"
+
     def __init__(self, filepath: Path) -> None:
         self.fileinfo: Fileinfo = Fileinfo(filepath)
         self.slide_num: int | None = None

--- a/src/proespm/spm/nid.py
+++ b/src/proespm/spm/nid.py
@@ -17,6 +17,8 @@ UNITS_REGEX = re.compile(r"[a-zA-Zµ°]+")
 
 @final
 class SpmNid(Measurement):
+    measurement_family = "SPM"
+
     def __init__(self, filepath: Path):
         self.fileinfo = Fileinfo(filepath)
         self.slide_num: int | None = None

--- a/src/proespm/spm/sm4.py
+++ b/src/proespm/spm/sm4.py
@@ -22,6 +22,8 @@ class StmSm4(Measurement):
         filepath (str): Full path to the .sm4 files
     """
 
+    measurement_family = "SPM"
+
     def __init__(self, filepath: Path) -> None:
         self.fileinfo = Fileinfo(filepath)
         self.slide_num: int | None = None

--- a/src/proespm/spm/sxm.py
+++ b/src/proespm/spm/sxm.py
@@ -20,6 +20,8 @@ class StmSxm(Measurement):
         filepath (str): Full path to the .sxm file
     """
 
+    measurement_family = "SPM"
+
     def __init__(self, filepath: Path) -> None:
         self.fileinfo = Fileinfo(filepath)
         self.slide_num: int | None = None

--- a/src/proespm/templates/base_template.j2
+++ b/src/proespm/templates/base_template.j2
@@ -21,13 +21,14 @@
     <div class="navbar">
         <ul>
             <li id="menu"><i data-feather="menu"></i></li>
+            <li><button onclick="toggleExpand()">Toggle Expand</button></li>
             <li ><a href="file:///{{ files_dir }}" >{{ title }}</a></li>
             <!-- <li class="navbar_li">{{ title }} - Report</li> -->
         </ul>
     </div>
 
     <!-- The collapsable overview grid, handeled by `overview.js` -->
-    <details open>
+    <details id="overview_root" open>
         <summary>Overview</summary>
         <div id="overview"></div>
     </details>
@@ -35,7 +36,24 @@
     <!-- Loop through the `measurement_objects` and choose the according template -->
     {% for measurement in measurement_objects %}
         {% if measurement.template_name is defined and measurement.template_name() %}
-            {% include measurement.template_name() %}
+            
+            {% if isinstance(measurement, ElabFTW) %}
+                {% include measurement.template_name() %}
+            {% else %}
+                <section>
+                <details closed>
+                <summary>
+                    {{ measurement.measurement_family }} - 
+                    {{ measurement.__class__.__name__ }} - 
+                    {{ measurement.controller ~ " - " if measurement.controller is defined and measurement.op_mode != None else "" }}
+                    {{ measurement.op_mode ~ " - " if measurement.op_mode is defined and measurement.op_mode != None else "" }}
+                    {{ measurement.fileinfo.filename }}
+                </summary>
+                {% include measurement.template_name() %}
+                </details>
+                </section>
+            {% endif %}
+            <hr />
         {% endif %}
     {% endfor %}
 
@@ -75,5 +93,6 @@
     <script>{% include 'overview.js' %}</script>
     <script>{% include 'modal.js' %}</script>
     <script>{% include 'top_button.js' %}</script>
+    <script>{% include 'toggle_expand.js' %}</script>
     <script>{% include 'sidebar.js' %}</script>
 </body>

--- a/src/proespm/templates/base_template.j2
+++ b/src/proespm/templates/base_template.j2
@@ -21,14 +21,14 @@
     <div class="navbar">
         <ul>
             <li id="menu"><i data-feather="menu"></i></li>
-            <li><button onclick="toggleExpand()">Toggle Expand</button></li>
+            <li><button id="lab-book-btn" onclick="toggleLabBookView()">Lab Book View</button></li>
             <li ><a href="file:///{{ files_dir }}" >{{ title }}</a></li>
             <!-- <li class="navbar_li">{{ title }} - Report</li> -->
         </ul>
     </div>
 
     <!-- The collapsable overview grid, handeled by `overview.js` -->
-    <details id="overview_root" open>
+    <details id="overview_root">
         <summary>Overview</summary>
         <div id="overview"></div>
     </details>
@@ -38,13 +38,15 @@
         {% if measurement.template_name is defined and measurement.template_name() %}
             
             {% if isinstance(measurement, ElabFTW) %}
+                <div id="{{ measurement.m_id() }}" class="elab-anchor">
                 {% include measurement.template_name() %}
+                </div>
             {% else %}
-                <section>
-                <details closed>
+                <section id="{{ measurement.m_id() }}">
+                <details open>
                 <summary>
-                    {{ measurement.measurement_family }} - 
-                    {{ measurement.__class__.__name__ }} - 
+                    {{ measurement.measurement_family }} -
+                    {{ measurement.__class__.__name__ }} -
                     {{ measurement.controller ~ " - " if measurement.controller is defined and measurement.op_mode != None else "" }}
                     {{ measurement.op_mode ~ " - " if measurement.op_mode is defined and measurement.op_mode != None else "" }}
                     {{ measurement.fileinfo.filename }}

--- a/src/proespm/templates/ec.j2
+++ b/src/proespm/templates/ec.j2
@@ -15,12 +15,12 @@
                 <td>{{ measurement.get_datetime().strftime("%Y-%m-%d") }} <br> {{ measurement.get_datetime().strftime("%H:%M:%S") }}</td>
             </tr>
             <tr>
-                <th>EC Type</th>
-                <td>{{ measurement.ec_type }}</td>
-            </tr>
-            <tr>
                 <th>Controller</th>
                 <td>{{ measurement.controller }}</td>
+            </tr>
+            <tr>
+                <th>Op. mode</th>
+                <td>{{ measurement.op_mode }}</td>
             </tr>
 
             {% if measurement.timestep %}
@@ -51,13 +51,13 @@
                     <td>{{ "%.2f"|format(measurement.u_start) }} V</td>
                 </tr>
 
-                {% if measurement.ec_type == 'Cyclic Voltammetry' %}
+                {% if measurement.op_mode == 'Cyclic Voltammetry' %}
                     <tr>
                         <th>E<sub>WE_1</sub> / E<sub>WE_2</sub></th>
                         <td>{{ "%.2f"|format(measurement.u_1) }} / {{ "%.2f"|format(measurement.u_2) }} V</td>
                     </tr>
 
-                {% elif measurement.ec_type == 'Chronoamperometry' %}
+                {% elif measurement.op_mode == 'Chronoamperometry' %}
                     <tr>
                         <th>E<sub>WE_max</sub> / E<sub>WE_min</sub></th>
                         <td>{{ "%.2f"|format(measurement.u_2) }} / {{ "%.2f"|format(measurement.u_1) }} V</td>
@@ -81,13 +81,13 @@
                     <td>{{ "%.2f"|format(measurement.u_bias_start) }} V</td>
                 </tr>
 
-                {% if measurement.ec_type == 'Cyclic Voltammetry' %}
+                {% if measurement.op_mode == 'Cyclic Voltammetry' %}
                     <tr>
                         <th>U<sub>b_1</sub> / U<sub>b_</sub></th>
                         <td>{{ "%.2f"|format(measurement.u_bias_1) }} / {{ "%.2f"|format(measurement.u_bias_2) }} V</td>
                     </tr>
 
-                {% elif measurement.ec_type == 'Chronoamperometry' %}
+                {% elif measurement.op_mode == 'Chronoamperometry' %}
                     <tr>
                         <th>U<sub>b_max</sub> / U<sub>b_min</sub></th>
                         <td>{{ "%.2f"|format(measurement.u_bias_2) }} / {{ "%.2f"|format(measurement.u_bias_1) }} V</td>

--- a/src/proespm/templates/elab_ftw.j2
+++ b/src/proespm/templates/elab_ftw.j2
@@ -1,33 +1,43 @@
-<div class="measurement-row" style="border-color: limegreen; border-width: 2px">
-    <div style="float: left; width: 30%; padding: 20px">
-        <table style="width=100%">
+<div class="measurement-row" style="border-color: {{ measurement.border_color }}; border-style: {{ measurement.border_style }}; border-width: 2px; padding: 10px 20px;">
+    <details class="elab-entry">
+        <summary>{{ measurement.text | safe }}</summary>
+        <table style="text-align: left; margin-top: 12px;">
             <tr>
-                <th id="{{ measurement.m_id() }}">ID</th>
+                <th id="{{ measurement.m_id() }}" style="padding-right: 12px;">ID</th>
                 <td>{{ measurement.m_id() }}</td>
             </tr>
             <tr>
-                <th>Datetime</th>
-                <td>{{ measurement.datetime().strftime("%Y-%m-%d %H:%M:%S") }}</td>
+                <th style="padding-right: 12px;">Datetime</th>
+                <td>{{ measurement.get_datetime().strftime("%Y-%m-%d %H:%M:%S") }}</td>
             </tr>
             <tr>
-                <th>Type</th>
+                <th style="padding-right: 12px;">Type</th>
                 <td>{{ measurement.type_ }}</td>
             </tr>
             <tr>
-                <th>Operator</th>
+                <th style="padding-right: 12px;">Owner</th>
                 <td>{{ measurement.operator }}</td>
             </tr>
             <tr>
-                <th>Team</th>
-                <td>{{ measurement.team }}</td>
+                <th style="padding-right: 12px;">Posted by</th>
+                <td>{{ measurement.initials }}</td>
             </tr>
             <tr>
-                <th>Tags</th>
+                <th style="padding-right: 12px;">elab-app</th>
+                <td>{{ measurement.app_version }}</td>
+            </tr>
+            {% if measurement.team %}
+            <tr>
+                <th style="padding-right: 12px;">Team</th>
+                <td>{{ measurement.team }}</td>
+            </tr>
+            {% endif %}
+            {% if measurement.tags %}
+            <tr>
+                <th style="padding-right: 12px;">Tags</th>
                 <td>{{ measurement.tags }}</td>
             </tr>
+            {% endif %}
         </table>
-    </div>
-    <div style="float: left; width: 40%;" >
-        <p style="font-size: 20px; text-align: justify">{{ measurement.text | safe }}</p>
-    </div>
+    </details>
 </div>

--- a/src/proespm/templates/elab_ftw.j2
+++ b/src/proespm/templates/elab_ftw.j2
@@ -1,39 +1,33 @@
-<div class="measurement-row elab-entry" style="border-color: limegreen; border-width: 2px">
-    <details closed>
-        <summary>
-            <span style="font-size: 20px; margin-left: 10; ">{{ measurement.text | safe }}</span>
-        </summary>
-
-        <!-- expansion -->
-        <div class="expansion">
-            <div style="float: left; width: 30%; padding: 20px">
-                <table style="width=100%">
-                    <tr>
-                        <th id="{{ measurement.m_id() }}">ID</th>
-                        <td>{{ measurement.m_id() }}</td>
-                    </tr>
-                    <tr>
-                        <th>Datetime</th>
-                        <td>{{ measurement.get_datetime().strftime("%Y-%m-%d %H:%M:%S") }}</td>
-                    </tr>
-                    <tr>
-                        <th>Type</th>
-                        <td>{{ measurement.type_ }}</td>
-                    </tr>
-                    <tr>
-                        <th>Operator</th>
-                        <td>{{ measurement.operator }}</td>
-                    </tr>
-                    <tr>
-                        <th>Team</th>
-                        <td>{{ measurement.team }}</td>
-                    </tr>
-                    <tr>
-                        <th>Tags</th>
-                        <td>{{ measurement.tags }}</td>
-                    </tr>
-                </table>
-            </div>
-        </div>
-    </details>
+<div class="measurement-row" style="border-color: limegreen; border-width: 2px">
+    <div style="float: left; width: 30%; padding: 20px">
+        <table style="width=100%">
+            <tr>
+                <th id="{{ measurement.m_id() }}">ID</th>
+                <td>{{ measurement.m_id() }}</td>
+            </tr>
+            <tr>
+                <th>Datetime</th>
+                <td>{{ measurement.datetime().strftime("%Y-%m-%d %H:%M:%S") }}</td>
+            </tr>
+            <tr>
+                <th>Type</th>
+                <td>{{ measurement.type_ }}</td>
+            </tr>
+            <tr>
+                <th>Operator</th>
+                <td>{{ measurement.operator }}</td>
+            </tr>
+            <tr>
+                <th>Team</th>
+                <td>{{ measurement.team }}</td>
+            </tr>
+            <tr>
+                <th>Tags</th>
+                <td>{{ measurement.tags }}</td>
+            </tr>
+        </table>
+    </div>
+    <div style="float: left; width: 40%;" >
+        <p style="font-size: 20px; text-align: justify">{{ measurement.text | safe }}</p>
+    </div>
 </div>

--- a/src/proespm/templates/elab_ftw.j2
+++ b/src/proespm/templates/elab_ftw.j2
@@ -1,33 +1,39 @@
-<div class="measurement-row" style="border-color: limegreen; border-width: 2px">
-    <div style="float: left; width: 30%; padding: 20px">
-        <table style="width=100%">
-            <tr>
-                <th id="{{ measurement.m_id() }}">ID</th>
-                <td>{{ measurement.m_id() }}</td>
-            </tr>
-            <tr>
-                <th>Datetime</th>
-                <td>{{ measurement.get_datetime().strftime("%Y-%m-%d %H:%M:%S") }}</td>
-            </tr>
-            <tr>
-                <th>Type</th>
-                <td>{{ measurement.type_ }}</td>
-            </tr>
-            <tr>
-                <th>Operator</th>
-                <td>{{ measurement.operator }}</td>
-            </tr>
-            <tr>
-                <th>Team</th>
-                <td>{{ measurement.team }}</td>
-            </tr>
-            <tr>
-                <th>Tags</th>
-                <td>{{ measurement.tags }}</td>
-            </tr>
-        </table>
-    </div>
-    <div style="float: left; width: 40%;" >
-        <p style="font-size: 20px; text-align: justify">{{ measurement.text | safe }}</p>
-    </div>
+<div class="measurement-row elab-entry" style="border-color: limegreen; border-width: 2px">
+    <details closed>
+        <summary>
+            <span style="font-size: 20px; margin-left: 10; ">{{ measurement.text | safe }}</span>
+        </summary>
+
+        <!-- expansion -->
+        <div class="expansion">
+            <div style="float: left; width: 30%; padding: 20px">
+                <table style="width=100%">
+                    <tr>
+                        <th id="{{ measurement.m_id() }}">ID</th>
+                        <td>{{ measurement.m_id() }}</td>
+                    </tr>
+                    <tr>
+                        <th>Datetime</th>
+                        <td>{{ measurement.get_datetime().strftime("%Y-%m-%d %H:%M:%S") }}</td>
+                    </tr>
+                    <tr>
+                        <th>Type</th>
+                        <td>{{ measurement.type_ }}</td>
+                    </tr>
+                    <tr>
+                        <th>Operator</th>
+                        <td>{{ measurement.operator }}</td>
+                    </tr>
+                    <tr>
+                        <th>Team</th>
+                        <td>{{ measurement.team }}</td>
+                    </tr>
+                    <tr>
+                        <th>Tags</th>
+                        <td>{{ measurement.tags }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </details>
 </div>

--- a/src/proespm/templates/mul.j2
+++ b/src/proespm/templates/mul.j2
@@ -1,8 +1,4 @@
 {% for img in measurement.mulimages %}
-    {% if img.m_id.endswith('_1') %}
-        <h2 id="{{ measurement.m_id }}">{{ img.basename }}</h2>
-    {% endif %}
-
     <div class="measurement-row">
       <div class="stm_image_fw">
         <img id="{{ img.m_id }}" src="{{ img.img_data.data_uri }}" class="hover-shadow" data-slide-num="{{ img.slide_num }}" />

--- a/src/proespm/templates/sidebar.js
+++ b/src/proespm/templates/sidebar.js
@@ -12,10 +12,29 @@ const sidebarItems = document
     .getElementsByClassName("sidebar-content")[0]
     .getElementsByTagName("li");
 
-/* Close the sidebar when one element is clicked */
+/* Close sidebar on click; in Lab Book View open the target section first, then scroll */
 for (it of sidebarItems) {
-    it.addEventListener("click", () => {
+    const anchor = it.querySelector('a');
+    if (!anchor) continue;
+
+    anchor.addEventListener("click", (e) => {
         sidebar.style.width = "0%"
         isSidebarOpen = false
-    })
+
+        if (document.body.classList.contains('lab-book-view')) {
+            const href = anchor.getAttribute('href');
+            if (href && href.startsWith('#')) {
+                const target = document.getElementById(href.slice(1));
+                const details = target?.querySelector(':scope > details');
+                if (details && !details.hasAttribute('open')) {
+                    e.preventDefault();                      // stop instant browser scroll
+                    details.setAttribute('open', '');        // open section
+                    history.pushState(null, null, href);     // update URL hash
+                    requestAnimationFrame(() => {            // scroll after layout reflow
+                        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    });
+                }
+            }
+        }
+    });
 }

--- a/src/proespm/templates/style.css
+++ b/src/proespm/templates/style.css
@@ -76,8 +76,21 @@ tr:nth-child(even) {
     color: white;
 }
 
+/* COLLAPSABLE MEASUREMENT ROWS */
+summary {
+  margin: 20px;
+  list-style: none;
+  cursor: pointer;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+summary::-webkit-details-marker {
+  display: none;
+}
+
 /* OVERVIEW */
-details {
+#overview_root {
     margin: 15px 20px;
     border-style: solid;
     border-width: 1px;
@@ -86,13 +99,14 @@ details {
     background-color: var(--row-bg-color);
 }
 
-details>summary {
+#overview_root>summary {
     cursor: pointer;
     padding: 15px 0 15px 20px;
     font-size: 1.2em;
+    margin: 0;
 }
 
-details>div {
+#overview_root>div {
     margin: 15px 20px 15px 20px;
 }
 

--- a/src/proespm/templates/style.css
+++ b/src/proespm/templates/style.css
@@ -76,17 +76,83 @@ tr:nth-child(even) {
     color: white;
 }
 
+.navbar button {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    color: white;
+    cursor: pointer;
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 18px;
+    transition: background 0.15s;
+}
+
+.navbar button.active {
+    background: rgba(255, 255, 255, 0.22);
+}
+
 /* COLLAPSABLE MEASUREMENT ROWS */
 summary {
   margin: 20px;
-  list-style: none;
   cursor: pointer;
   font-size: 20px;
   font-weight: bold;
 }
 
-summary::-webkit-details-marker {
-  display: none;
+/* Default mode: measurement summaries invisible — cards appear like matkrin */
+section > details > summary {
+    display: none;
+}
+
+/* Lab Book View: reveal summaries and make them collapsible */
+body.lab-book-view section > details > summary {
+    display: block;
+}
+
+/* elab-entry — spans full width of the flex card */
+details.elab-entry {
+    flex: 0 0 100%;
+}
+
+details.elab-entry > summary {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    margin: 0;
+    font-size: 16px;
+    font-weight: normal;
+    color: inherit;
+    cursor: pointer;
+}
+
+details.elab-entry > summary::marker {
+    display: none;
+}
+
+details.elab-entry > summary::-webkit-details-marker {
+    display: none;
+}
+
+/* reset margins on block elements rendered inside the log text */
+details.elab-entry > summary > p,
+details.elab-entry > summary > div {
+    flex: 1;
+    margin: 0;
+    text-align: justify;
+}
+
+details.elab-entry > summary::after {
+    content: "▶";
+    color: #bbb;
+    font-size: 12px;
+    flex-shrink: 0;
+    margin-left: 12px;
+    align-self: center;
+}
+
+details.elab-entry[open] > summary::after {
+    content: "▼";
+    color: #888;
 }
 
 /* OVERVIEW */
@@ -132,6 +198,11 @@ summary::-webkit-details-marker {
     margin: 0 0 7px 0;
     max-width: 200px;
     text-align: center;
+}
+
+section,
+.elab-anchor {
+    scroll-margin-top: 55px;
 }
 
 .measurement-row {

--- a/src/proespm/templates/toggle_expand.js
+++ b/src/proespm/templates/toggle_expand.js
@@ -1,0 +1,8 @@
+function toggleExpand(){
+document.body.querySelectorAll('details')
+    .forEach((e) => {
+        (e.hasAttribute('open') && e.id != "overview_root" && !e.classList.contains("elab-entry"))
+            ? e.removeAttribute('open')
+            : e.setAttribute('open',false);
+    })
+}

--- a/src/proespm/templates/toggle_expand.js
+++ b/src/proespm/templates/toggle_expand.js
@@ -1,8 +1,20 @@
-function toggleExpand(){
-document.body.querySelectorAll('details')
-    .forEach((e) => {
-        (e.hasAttribute('open') && e.id != "overview_root" && !e.classList.contains("elab-entry"))
-            ? e.removeAttribute('open')
-            : e.setAttribute('open',false);
-    })
+function toggleLabBookView() {
+    const btn = document.getElementById('lab-book-btn');
+    const overview = document.getElementById('overview_root');
+    const sections = [...document.querySelectorAll('section > details')];
+    const entering = !btn.classList.contains('active');
+
+    if (entering) {
+        // Enter Lab Book View: everything starts collapsed
+        document.body.classList.add('lab-book-view');
+        overview.removeAttribute('open');
+        sections.forEach(d => d.removeAttribute('open'));
+        btn.classList.add('active');
+    } else {
+        // Exit Lab Book View: restore plain card view (sections must be open so cards show)
+        document.body.classList.remove('lab-book-view');
+        overview.removeAttribute('open');
+        sections.forEach(d => d.setAttribute('open', ''));
+        btn.classList.remove('active');
+    }
 }

--- a/tests/testdata/NAP-STM_16450.json
+++ b/tests/testdata/NAP-STM_16450.json
@@ -1,0 +1,758 @@
+{
+  "body_html": "<table>\n<tr><td>elab_app</td><td>https://github.com/ffelsen/elab_app</td><td></td><td></td></tr>\n<tr><th>ISO time<br>(ISO 8601)</th><th>Log<br>(newest to oldest)</th><th>Initials</th><th>App<br>version</th></tr>\n<tr><td>2026-05-27T08:51:56</td><td><p>pressures in the morning: STM=2.24e-10, Prep= 1.2e-9, LL=2.6e-8</p></td><td>nap</td><td>v3.2</td></tr>\n</table>",
+  "changelog": [
+    {
+      "created_at": "2026-05-27 08:52:05",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-26 09:04:52",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-22 08:52:17",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-21 10:58:33",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-20 13:46:28",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-05-20 09:11:00",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-19 10:50:17",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-05-18 16:12:31",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-05-18 13:24:58",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-05-15 18:24:20",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-15 18:24:08",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-15 18:24:04",
+      "target": "links",
+      "content": "Added link to resource: <a href=\"/database.php?mode=view&amp;id=20759\">W tip 260515</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-15 18:06:34",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-15 18:04:59",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-15 18:04:14",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-15 18:02:24",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-14 10:46:25",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-12 09:58:33",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-11 10:57:08",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-05-11 10:53:08",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-05-11 10:00:32",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-05-11 09:59:19",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-05-08 08:51:00",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-07 12:04:53",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-06 19:11:05",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-06 19:04:43",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-06 19:04:22",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-06 19:03:47",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-06 10:34:10",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-06 10:34:04",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-06 10:33:10",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-06 09:08:11",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-06 08:44:53",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 18:47:24",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 18:47:01",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 16:38:29",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 16:37:56",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 16:27:09",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 09:14:22",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 08:52:10",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 08:51:33",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 08:51:31",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 08:50:53",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 08:50:29",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 08:50:19",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 08:49:35",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 08:48:55",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 08:47:46",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-05 08:46:39",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-04 18:17:45",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-04 17:21:59",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-04 16:58:36",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-04 13:00:01",
+      "target": "links",
+      "content": "Added link to resource: <a href=\"/database.php?mode=view&amp;id=18381\">Fe3O4(100)</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-04 13:00:01",
+      "target": "links",
+      "content": "Added link to resource: <a href=\"/database.php?mode=view&amp;id=18380\">Fe2O3(012) TU Wien</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-05-04 13:00:01",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-04-21 15:20:14",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-04-21 15:12:02",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-21 13:56:53",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-21 13:53:58",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-21 13:53:48",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-21 12:31:01",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-21 12:10:47",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-21 12:07:51",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-21 11:52:16",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-20 15:28:54",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-20 15:09:02",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-04-20 14:57:24",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-04-20 14:46:43",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-04-20 13:52:01",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-20 09:30:33",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-17 10:49:13",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-17 10:32:11",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-15 17:54:28",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-04-14 08:52:06",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "User NAP-STM",
+      "userid": 521
+    },
+    {
+      "created_at": "2026-04-10 09:54:59",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-04-08 13:27:12",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-04-08 13:27:11",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-04-08 13:25:41",
+      "target": "links",
+      "content": "Added link to resource: <a href=\"/database.php?mode=view&amp;id=16452\">TiO2(110) #2.11 LR</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-04-08 13:25:41",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-04-08 09:35:49",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-04-08 09:34:57",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-04-07 16:24:47",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-07 16:24:46",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-07 13:46:26",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-07 13:46:20",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-07 13:45:22",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-07 13:44:58",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-07 13:44:46",
+      "target": "date",
+      "content": "2026-03-24",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-07 13:23:08",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-07 08:47:14",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-02 20:37:37",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-01 09:01:08",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-04-01 09:00:44",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Marina de la Higuera",
+      "userid": 512
+    },
+    {
+      "created_at": "2026-03-24 17:21:40",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    },
+    {
+      "created_at": "2026-03-24 17:20:58",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=16450\">See revisions page.</a>",
+      "fullname": "Lorenz Falling",
+      "userid": 509
+    }
+  ],
+  "comments": [],
+  "compounds_links": [],
+  "created_at": "2026-03-24 16:34:10",
+  "elabid": "20260324-5f6be606e1a15f20a3725dcb79645083efb89120",
+  "experiments_links": [],
+  "firstname": "Lorenz",
+  "fullname": "Lorenz Falling",
+  "hide_main_text": 0,
+  "id": 16450,
+  "items_links": [
+    {
+      "entityid": 16452,
+      "title": "TiO2(110) #2.11 LR",
+      "is_bookable": 0,
+      "link_state": 1,
+      "page": "database.php",
+      "type": "items"
+    },
+    {
+      "entityid": 18380,
+      "title": "Fe2O3(012) #626 (TU Wien)",
+      "is_bookable": 0,
+      "link_state": 1,
+      "page": "database.php",
+      "type": "items"
+    },
+    {
+      "entityid": 18381,
+      "title": "Fe3O4(100) #3.2",
+      "is_bookable": 0,
+      "link_state": 1,
+      "page": "database.php",
+      "type": "items"
+    }
+  ],
+  "lastchangeby": 521,
+  "lastname": "Falling",
+  "locked": 0,
+  "modified_at": "2026-05-27 08:52:05",
+  "page": "database",
+  "related_experiments_links": [
+    {
+      "entityid": 4729,
+      "title": "Ni on TiO2(110)",
+      "link_state": 1,
+      "page": "experiments.php",
+      "type": "experiments"
+    },
+    {
+      "entityid": 4731,
+      "title": "Pt on TiO2(110)",
+      "link_state": 1,
+      "page": "experiments.php",
+      "type": "experiments"
+    },
+    {
+      "entityid": 4751,
+      "title": "elab_app testing",
+      "link_state": 1,
+      "page": "experiments.php",
+      "type": "experiments"
+    },
+    {
+      "entityid": 5310,
+      "title": "Fe2O3(012)",
+      "link_state": 1,
+      "page": "experiments.php",
+      "type": "experiments"
+    }
+  ],
+  "related_items_links": [],
+  "sharelink": "https://eln.ub.tum.de/database.php?mode=view&id=16450",
+  "steps": [],
+  "timestamped": 0,
+  "type": "items",
+  "uploads": [],
+  "body": "<table>\n<tr><td>elab_app</td><td>https://github.com/ffelsen/elab_app</td><td></td><td></td></tr>\n<tr><th>ISO time<br>(ISO 8601)</th><th>Log<br>(newest to oldest)</th><th>Initials</th><th>App<br>version</th></tr>\n<tr><td>2026-05-27T08:51:56</td><td><p>pressures in the morning: STM=2.24e-10, Prep= 1.2e-9, LL=2.6e-8</p></td><td>nap</td><td>v3.2</td></tr>\n</table>",
+  "canread_base": 30.0,
+  "canread": "{\"teams\": [], \"users\": [], \"teamgroups\": []}",
+  "canwrite_base": 30.0,
+  "canwrite": "{\"teams\": [], \"users\": [], \"teamgroups\": []}",
+  "date": "2026-03-24",
+  "content_type": 1,
+  "rating": 0,
+  "state": 1,
+  "title": "NAP-STM",
+  "template": -1,
+  "userid": 509
+}

--- a/tests/testdata/UHV-STM-A_1001.json
+++ b/tests/testdata/UHV-STM-A_1001.json
@@ -1,0 +1,90 @@
+{
+  "body_html": "<table>\n<tr><td>elab_app</td><td>https://github.com/ffelsen/elab_app</td><td></td><td></td></tr>\n<tr><th>ISO time<br>(ISO 8601)</th><th>Log<br>(newest to oldest)</th><th>Initials</th><th>App<br>version</th></tr>\n<tr><td>2026-02-21T09:14:22</td><td><p>Morning pressures: Analysis=1.8e-10 mbar, Prep=4.2e-9 mbar, LL=3.1e-8 mbar. System stable.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2026-02-10T10:30:05</td><td><p>Exchanged tip (W wire, electrochemically etched). First approach on Au(111) reference successful. Atomic steps clearly resolved.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2026-01-15T08:45:33</td><td><p>New sample loaded into prep chamber. Starting degassing at 450 K for 2 h before transfer.</p></td><td>ac</td><td>v3.2</td></tr>\n<tr><td>2025-11-20T14:22:10</td><td><p>Bakeout finished after 72 h at 120 C. Base pressure recovered to 2.1e-10 mbar in analysis chamber.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2025-09-08T09:05:44</td><td><p>Pressures this morning: Analysis=2.0e-10 mbar, Prep=5.8e-9 mbar, LL=2.9e-8 mbar.</p></td><td>ac</td><td>v3.2</td></tr>\n<tr><td>2025-06-17T11:33:27</td><td><p>Tip characterization on clean reference surface: lateral resolution ~2 A, noise floor 3 pm. Good imaging condition confirmed.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2025-03-04T10:15:02</td><td><p>Sample B transferred from prep to analysis chamber. Temperature at transfer: 310 K. First scan shows clean terraces.</p></td><td>ac</td><td>v3.2</td></tr>\n<tr><td>2024-12-11T09:02:18</td><td><p>Morning pressures: Analysis=1.9e-10 mbar, Prep=4.5e-9 mbar. Slight uptick in prep chamber—checked ion gauge, reading nominal.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2024-08-22T13:45:55</td><td><p>Calibrated scanner piezo using Au(111) monoatomic step height (2.35 A). x/y calibration within 2% of nominal value.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2024-04-30T08:58:11</td><td><p>Tip flashed at 800 K for 10 s. Imaging quality improved noticeably, tunnelling noise reduced.</p></td><td>ac</td><td>v3.2</td></tr>\n<tr><td>2024-01-10T11:00:05</td><td><p>[elab-app] Experiment <a href=\"https://eln.example.org/experiments.php?mode=view&amp;id=42\" target=\"_blank\" rel=\"noreferrer noopener\">Surface Study 2024</a> tagged this resource. Posted by ac.</p></td><td>#</td><td>v3.2</td></tr>\n<tr><td>2023-11-14T10:20:36</td><td><p>Sample A loaded. Sputter cycle: Ar+ at 1 keV, 1e-5 mbar Ar, 20 min. Anneal at 900 K for 15 min. Surface looks clean in LEED.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2023-07-03T09:11:49</td><td><p>Pressures: Analysis=2.2e-10 mbar, Prep=6.1e-9 mbar. No anomalies.</p></td><td>ac</td><td>v3.2</td></tr>\n<tr><td>2023-02-20T11:04:22</td><td><p>Tip exchange after accidental crash. New tip installed and approached at 50 pA / 1.0 V. Feedback stable.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2022-09-12T14:33:08</td><td><p>Started bakeout of load-lock. Temperature ramp 2 K/min up to 120 C. Estimated duration 48 h.</p></td><td>ac</td><td>v3.2</td></tr>\n<tr><td>2022-04-05T09:45:17</td><td><p>Good imaging session. Scan range 100x100 nm, 256x256 px, 200 ms/line. Step-and-terrace structure well resolved, step height 2.0 A.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2021-10-18T10:22:41</td><td><p>Pressures: Analysis=1.7e-10 mbar, Prep=3.9e-9 mbar. System performing well after filament replacement.</p></td><td>ac</td><td>v3.1</td></tr>\n<tr><td>2021-05-07T13:55:29</td><td><p>Characterised new tip on reference crystal. Single-atom resolution achieved at 200 pA / 500 mV. Ready for experiment.</p></td><td>js</td><td>v3.1</td></tr>\n<tr><td>2020-11-23T09:08:14</td><td><p>Sample transferred to analysis chamber. No contamination visible in first overview scan (500x500 nm).</p></td><td>ac</td></tr>\n<tr><td>2020-06-16T11:30:55</td><td><p>Pressures: Analysis=2.3e-10 mbar, Prep=7.2e-9 mbar. Turbo pump replaced last week, system still recovering.</p></td><td>js</td></tr>\n<tr><td>2020-01-09T08:52:07</td><td><p>System startup after annual maintenance. All gauges reading nominal. Starting conditioning scan on reference sample.</p></td><td>js</td></tr>\n</table>",
+  "changelog": [
+    {
+      "created_at": "2026-02-21 09:14:35",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=1001\">See revisions page.</a>",
+      "fullname": "Jane Smith",
+      "userid": 1
+    },
+    {
+      "created_at": "2026-02-10 10:30:20",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=1001\">See revisions page.</a>",
+      "fullname": "Jane Smith",
+      "userid": 1
+    },
+    {
+      "created_at": "2026-01-15 08:45:50",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=1001\">See revisions page.</a>",
+      "fullname": "Alex Chen",
+      "userid": 2
+    },
+    {
+      "created_at": "2024-01-10 11:00:10",
+      "target": "links",
+      "content": "Added link to experiment: <a href=\"/experiments.php?mode=view&amp;id=42\">Surface Study 2024</a>",
+      "fullname": "Alex Chen",
+      "userid": 2
+    },
+    {
+      "created_at": "2020-01-08 15:30:00",
+      "target": "body",
+      "content": "Depending on your instance configuration, the change in the body is possibly recorded in the revisions. <a href=\"revisions.php?type=items&amp;item_id=1001\">See revisions page.</a>",
+      "fullname": "Jane Smith",
+      "userid": 1
+    }
+  ],
+  "comments": [],
+  "compounds_links": [],
+  "created_at": "2020-01-08 15:30:00",
+  "elabid": "20200108-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+  "experiments_links": [
+    {
+      "entityid": 42,
+      "title": "Surface Study 2024",
+      "link_state": 1,
+      "page": "experiments.php",
+      "type": "experiments"
+    }
+  ],
+  "firstname": "Jane",
+  "fullname": "Jane Smith",
+  "hide_main_text": 0,
+  "id": 1001,
+  "items_links": [],
+  "lastchangeby": 1,
+  "lastname": "Smith",
+  "locked": 0,
+  "modified_at": "2026-02-21 09:14:35",
+  "page": "database",
+  "related_experiments_links": [
+    {
+      "entityid": 42,
+      "title": "Surface Study 2024",
+      "link_state": 1,
+      "page": "experiments.php",
+      "type": "experiments"
+    }
+  ],
+  "related_items_links": [],
+  "sharelink": "https://eln.example.org/database.php?mode=view&id=1001",
+  "steps": [],
+  "timestamped": 0,
+  "type": "items",
+  "uploads": [],
+  "body": "<table>\n<tr><td>elab_app</td><td>https://github.com/ffelsen/elab_app</td><td></td><td></td></tr>\n<tr><th>ISO time<br>(ISO 8601)</th><th>Log<br>(newest to oldest)</th><th>Initials</th><th>App<br>version</th></tr>\n<tr><td>2026-02-21T09:14:22</td><td><p>Morning pressures: Analysis=1.8e-10 mbar, Prep=4.2e-9 mbar, LL=3.1e-8 mbar. System stable.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2026-02-10T10:30:05</td><td><p>Exchanged tip (W wire, electrochemically etched). First approach on Au(111) reference successful. Atomic steps clearly resolved.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2026-01-15T08:45:33</td><td><p>New sample loaded into prep chamber. Starting degassing at 450 K for 2 h before transfer.</p></td><td>ac</td><td>v3.2</td></tr>\n<tr><td>2025-11-20T14:22:10</td><td><p>Bakeout finished after 72 h at 120 C. Base pressure recovered to 2.1e-10 mbar in analysis chamber.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2025-09-08T09:05:44</td><td><p>Pressures this morning: Analysis=2.0e-10 mbar, Prep=5.8e-9 mbar, LL=2.9e-8 mbar.</p></td><td>ac</td><td>v3.2</td></tr>\n<tr><td>2025-06-17T11:33:27</td><td><p>Tip characterization on clean reference surface: lateral resolution ~2 A, noise floor 3 pm. Good imaging condition confirmed.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2025-03-04T10:15:02</td><td><p>Sample B transferred from prep to analysis chamber. Temperature at transfer: 310 K. First scan shows clean terraces.</p></td><td>ac</td><td>v3.2</td></tr>\n<tr><td>2024-12-11T09:02:18</td><td><p>Morning pressures: Analysis=1.9e-10 mbar, Prep=4.5e-9 mbar. Slight uptick in prep chamber—checked ion gauge, reading nominal.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2024-08-22T13:45:55</td><td><p>Calibrated scanner piezo using Au(111) monoatomic step height (2.35 A). x/y calibration within 2% of nominal value.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2024-04-30T08:58:11</td><td><p>Tip flashed at 800 K for 10 s. Imaging quality improved noticeably, tunnelling noise reduced.</p></td><td>ac</td><td>v3.2</td></tr>\n<tr><td>2024-01-10T11:00:05</td><td><p>[elab-app] Experiment <a href=\"https://eln.example.org/experiments.php?mode=view&amp;id=42\" target=\"_blank\" rel=\"noreferrer noopener\">Surface Study 2024</a> tagged this resource. Posted by ac.</p></td><td>#</td><td>v3.2</td></tr>\n<tr><td>2023-11-14T10:20:36</td><td><p>Sample A loaded. Sputter cycle: Ar+ at 1 keV, 1e-5 mbar Ar, 20 min. Anneal at 900 K for 15 min. Surface looks clean in LEED.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2023-07-03T09:11:49</td><td><p>Pressures: Analysis=2.2e-10 mbar, Prep=6.1e-9 mbar. No anomalies.</p></td><td>ac</td><td>v3.2</td></tr>\n<tr><td>2023-02-20T11:04:22</td><td><p>Tip exchange after accidental crash. New tip installed and approached at 50 pA / 1.0 V. Feedback stable.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2022-09-12T14:33:08</td><td><p>Started bakeout of load-lock. Temperature ramp 2 K/min up to 120 C. Estimated duration 48 h.</p></td><td>ac</td><td>v3.2</td></tr>\n<tr><td>2022-04-05T09:45:17</td><td><p>Good imaging session. Scan range 100x100 nm, 256x256 px, 200 ms/line. Step-and-terrace structure well resolved, step height 2.0 A.</p></td><td>js</td><td>v3.2</td></tr>\n<tr><td>2021-10-18T10:22:41</td><td><p>Pressures: Analysis=1.7e-10 mbar, Prep=3.9e-9 mbar. System performing well after filament replacement.</p></td><td>ac</td><td>v3.1</td></tr>\n<tr><td>2021-05-07T13:55:29</td><td><p>Characterised new tip on reference crystal. Single-atom resolution achieved at 200 pA / 500 mV. Ready for experiment.</p></td><td>js</td><td>v3.1</td></tr>\n<tr><td>2020-11-23T09:08:14</td><td><p>Sample transferred to analysis chamber. No contamination visible in first overview scan (500x500 nm).</p></td><td>ac</td></tr>\n<tr><td>2020-06-16T11:30:55</td><td><p>Pressures: Analysis=2.3e-10 mbar, Prep=7.2e-9 mbar. Turbo pump replaced last week, system still recovering.</p></td><td>js</td></tr>\n<tr><td>2020-01-09T08:52:07</td><td><p>System startup after annual maintenance. All gauges reading nominal. Starting conditioning scan on reference sample.</p></td><td>js</td></tr>\n</table>",
+  "canread_base": 30.0,
+  "canread": "{\"teams\": [], \"users\": [], \"teamgroups\": []}",
+  "canwrite_base": 30.0,
+  "canwrite": "{\"teams\": [], \"users\": [], \"teamgroups\": []}",
+  "date": "2020-01-08",
+  "content_type": 1,
+  "rating": 0,
+  "state": 1,
+  "title": "UHV-STM System A",
+  "template": -1,
+  "userid": 1
+}


### PR DESCRIPTION
We updated the appearance of the html report so that it can show a lab-book-like text view. If there are json exports from ElabFTW containing elab-app log entries in the data folder, they will appear formatted based on their ElabFTW ID. Currently only ElabFTW with elab-app tables are supported as lab book entries, due to their normalized, time-stamped appearance. Fi no entries are shown, the initial view of the report should be largely unchanged. Fixed some issues with jumping to the anchors via the taskbar as well.

Furthermore, we did some remaining of fields (mostly electrochemistry and STM) to be more consistent.