### PR TITLE
fix(ec_labview): parse CV files with defective rows

### DIFF
--- a/src/proespm/ec/ec_labview.py
+++ b/src/proespm/ec/ec_labview.py
@@ -1,5 +1,7 @@
 import io
 import os
+import warnings
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from typing import Self, final, override
@@ -12,6 +14,88 @@ from proespm.config import Config
 from proespm.ec.ec import EcPlot
 from proespm.fileinfo import Fileinfo
 from proespm.measurement import Measurement
+
+
+def _to_float(value: str) -> float:
+    """Convert a single cell to float, empty or invalid cells become NaN."""
+
+    value = value.strip()
+    if not value:
+        return np.nan
+
+    try:
+        return float(value)
+    except ValueError:
+        return np.nan
+
+
+def _read_labview_data(filepath: Path) -> tuple[NDArray[np.float64], list[str]]:
+    """Read the numeric data of a LabView file as numpy array.
+
+    Replacement for a plain `np.loadtxt` call, which aborts on any row that
+    deviates from the column count of the first row. Two defects occur in
+    practice and are handled here:
+
+    - A cell is empty (acquisition glitch). Splitting on whitespace would
+      silently drop the column, so the row is split on the actual delimiter
+      and the missing value becomes NaN.
+    - A row has a deviating number of columns (usually a truncated last line
+      of an aborted measurement). The row is dropped.
+
+    Args:
+        filepath: Full path of the LabView file.
+
+    Returns:
+        Tuple of the numeric data (without the header line) and a list of
+        messages describing every defect that was repaired.
+    """
+
+    with open(filepath, "rb") as f:
+        raw = f.read()
+
+    text = raw.replace(b"\r\n", b"\n").replace(b"\r", b"\n").decode("latin-1")
+
+    lines = [line for line in text.split("\n")[1:] if line.strip()]
+    if not lines:
+        raise ValueError(f"{filepath.name}: file contains no data rows")
+
+    delimiter = "\t" if "\t" in lines[0] else None
+    rows = [
+        line.split(delimiter) if delimiter is not None else line.split()
+        for line in lines
+    ]
+
+    counts = Counter(len(row) for row in rows)
+    n_cols = counts.most_common(1)[0][0]
+
+    messages: list[str] = []
+    if len(counts) > 1:
+        dropped = [
+            (i, len(row)) for i, row in enumerate(rows) if len(row) != n_cols
+        ]
+        rows = [row for row in rows if len(row) == n_cols]
+        preview = ", ".join(
+            f"line {i + 2} ({n} instead of {n_cols} columns)"
+            for i, n in dropped[:5]
+        )
+        if len(dropped) > 5:
+            preview += f", ... ({len(dropped)} rows in total)"
+        messages.append(f"{filepath.name}: dropped malformed rows: {preview}")
+
+    if not rows:
+        raise ValueError(f"{filepath.name}: no consistent data rows found")
+
+    data = np.array(
+        [[_to_float(cell) for cell in row] for row in rows], dtype=np.float64
+    )
+
+    n_nan = int(np.count_nonzero(np.isnan(data)))
+    if n_nan > 0:
+        messages.append(
+            f"{filepath.name}: {n_nan} empty or invalid values replaced by NaN"
+        )
+
+    return data, messages
 
 
 @final
@@ -32,6 +116,7 @@ class CvLabview(Measurement):
         self.fileinfo = Fileinfo(filepath)
 
         self.type: str | None = None
+        self.parse_warnings: list[str] = []
         self.data = self.read_cv_data(filepath)
 
         self.u_start: float | None = None
@@ -57,12 +142,12 @@ class CvLabview(Measurement):
     def read_cv_data(self, filepath: Path) -> NDArray[np.float64]:
         """Read the numeric data as numpy array"""
 
-        with open(filepath, "rb") as f:
-            raw = f.read()
+        data, messages = _read_labview_data(filepath)
+        self.parse_warnings.extend(messages)
+        for message in messages:
+            warnings.warn(message, RuntimeWarning, stacklevel=2)
 
-        raw = raw.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
-
-        return np.loadtxt(io.BytesIO(raw), skiprows=1)
+        return data
 
     def read_params(self) -> None:
         """Calculate relevent parameters"""
@@ -76,20 +161,20 @@ class CvLabview(Measurement):
             self.u_bias_start = self.data[0, 4]
 
         if np.sign(self.data[10, 1] - self.data[0, 1]) < 0:
-            self.u_1 = float(np.min(self.data[:, 1]))
-            self.u_2 = float(np.max(self.data[:, 1]))
+            self.u_1 = float(np.nanmin(self.data[:, 1]))
+            self.u_2 = float(np.nanmax(self.data[:, 1]))
 
             if is_bias_valid:
-                self.u_bias_1 = float(np.min(self.data[:, 4]))
-                self.u_bias_2 = float(np.max(self.data[:, 4]))
+                self.u_bias_1 = float(np.nanmin(self.data[:, 4]))
+                self.u_bias_2 = float(np.nanmax(self.data[:, 4]))
 
         else:
-            self.u_1 = float(np.max(self.data[:, 1]))
-            self.u_2 = float(np.min(self.data[:, 1]))
+            self.u_1 = float(np.nanmax(self.data[:, 1]))
+            self.u_2 = float(np.nanmin(self.data[:, 1]))
 
             if is_bias_valid:
-                self.u_bias_1 = float(np.max(self.data[:, 4]))
-                self.u_bias_2 = float(np.min(self.data[:, 4]))
+                self.u_bias_1 = float(np.nanmax(self.data[:, 4]))
+                self.u_bias_2 = float(np.nanmin(self.data[:, 4]))
 
         self.timestep = (
             1000
@@ -112,6 +197,18 @@ class CvLabview(Measurement):
 
         x = self.data[:, 1]  # voltage
         y = self.data[:, 2]  # current
+
+        # Rows with repaired (NaN) values would poison the travel distance
+        # below, so they are excluded from the cycle detection.
+        finite = np.isfinite(x) & np.isfinite(y)
+        x = x[finite]
+        y = y[finite]
+
+        if len(x) < 2:
+            raise ValueError(
+                f"{self.fileinfo.filename}: too few valid data points"
+                " for cycle detection"
+            )
 
         cycle_start_indices = [0]
 

--- a/tests/test_ec_labview.py
+++ b/tests/test_ec_labview.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from proespm.ec.ec_labview import _read_labview_data
+
+testdata = Path(__file__).parent / "testdata" / "ec_labview"
+cv_file = testdata / "CV_251010_001.csv"
+
+
+def _data_lines(filepath: Path) -> list[str]:
+    """Normalized, non-empty lines of a LabView file, header included."""
+
+    text = (
+        filepath.read_bytes()
+        .replace(b"\r\n", b"\n")
+        .replace(b"\r", b"\n")
+        .decode("latin-1")
+    )
+
+    return [line for line in text.split("\n") if line.strip()]
+
+
+def test_intact_cv_file():
+    data, messages = _read_labview_data(cv_file)
+
+    assert data.shape[1] == 9
+    assert messages == []
+    assert np.isfinite(data).all()
+
+
+def test_truncated_row_is_dropped(tmp_path: Path):
+    """An aborted acquisition leaves an incomplete final line."""
+
+    lines = _data_lines(cv_file)
+    lines[100] = "\t".join(lines[100].split("\t")[:8])
+
+    broken = tmp_path / "CV_truncated.csv"
+    _ = broken.write_text("\n".join(lines) + "\n")
+
+    data, messages = _read_labview_data(broken)
+
+    assert data.shape == (len(lines) - 2, 9)
+    assert len(messages) == 1
+    assert "line 101" in messages[0]
+
+
+def test_empty_cell_becomes_nan(tmp_path: Path):
+    """An empty cell must not silently shift the columns."""
+
+    lines = _data_lines(cv_file)
+    fields = lines[100].split("\t")
+    fields[3] = ""
+    lines[100] = "\t".join(fields)
+
+    broken = tmp_path / "CV_empty_cell.csv"
+    _ = broken.write_text("\n".join(lines) + "\n")
+
+    data, messages = _read_labview_data(broken)
+
+    assert data.shape == (len(lines) - 1, 9)
+    assert np.isnan(data[99, 3])
+    assert np.count_nonzero(np.isnan(data)) == 1
+    assert len(messages) == 1
+
+
+def test_header_only_file_raises(tmp_path: Path):
+    empty = tmp_path / "CV_header_only.csv"
+    _ = empty.write_text(_data_lines(cv_file)[0] + "\n")
+
+    with pytest.raises(ValueError):
+        _ = _read_labview_data(empty)


### PR DESCRIPTION
    np.loadtxt aborts as soon as a row deviates from the column count of
    the first row, so a single defective line makes a whole LabView CV file
    unreadable:

        ValueError: the number of columns changed from 9 to 8 at row 1758

    Two defects occur in practice. A row can be truncated, typically the
    last line of an aborted acquisition. A single cell can be empty; since
    loadtxt was called without a delimiter it split on whitespace, so the
    empty cell did not become NaN but silently removed a column from that
    row.

    Add _read_labview_data() and use it in CvLabview.read_cv_data(). It
    splits on the actual delimiter, turns empty or unparseable cells into
    NaN, drops rows whose column count deviates from the file's modal
    count, and reports every repair. The messages are stored in the new
    parse_warnings attribute and emitted as RuntimeWarning, so a repaired
    file is visible on stderr and in the test run.

    Because a repaired row can carry NaN, read_params() uses np.nanmin and
    np.nanmax, and split_cycles() masks non-finite points before the cycle
    detection, where a single NaN would otherwise make the accumulated
    travel distance NaN and suppress every cycle.

    CaLabview and FftLabview are deliberately left unchanged. Intact CV
    files parse bit-identically to the previous implementation.
    EOF